### PR TITLE
Add Package-Requires header for ELPA installations

### DIFF
--- a/bbdb-vcard.el
+++ b/bbdb-vcard.el
@@ -5,6 +5,7 @@
 ;; Author: Bert Burgemeister <trebbu@googlemail.com>
 ;; Keywords: data calendar mail news
 ;; URL: http://github.com/trebb/bbdb-vcard
+;; Package-Requires: ((bbdb "3.0"))
 ;; Version: 0.3
 
 ;; This program is free software; you can redistribute it and/or


### PR DESCRIPTION
When installing this package from Melpa (or any other ELPA
repository in which it might be found) then `bbdb` should also
be installed. This commit adds the corresponding `Package-Requires`
header. Feel free to adjust the required version if desired.
